### PR TITLE
Update paths for Ventura

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ these libraries from the cache for reverse engineering.
 Extract the default shared cache to `/tmp/libraries`:
 
 ```sh
-dyld-shared-cache-extractor /System/Library/dyld/dyld_shared_cache_arm64e /tmp/libraries
+dyld-shared-cache-extractor /System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e /tmp/libraries
 ```
 
 If this fails it could be because the shared cache format has changed,
@@ -22,7 +22,14 @@ you're trying to extract the cache from a beta OS version) and override
 the Xcode version when running `dyld-shared-cache-extractor`:
 
 ```sh
-DEVELOPER_DIR=/Applications/Xcode-beta.app dyld-shared-cache-extractor /System/Library/dyld/dyld_shared_cache_arm64e /tmp/libraries
+DEVELOPER_DIR=/Applications/Xcode-beta.app dyld-shared-cache-extractor /System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e /tmp/libraries
+```
+
+On macOS versions before Ventura the shared cache was in a different
+location, you can extract on older macOS versions with:
+
+```sh
+dyld-shared-cache-extractor /System/Library/dyld/dyld_shared_cache_arm64e /tmp/libraries
 ```
 
 ## Installation


### PR DESCRIPTION
This just puts the Ventura paths front and center and adds a note about
the old paths below.

Fixes https://github.com/keith/dyld-shared-cache-extractor/issues/4
